### PR TITLE
Added required initialiser to allow for generic instantiation

### DIFF
--- a/Sources/libgir2swift/gir+swift.swift
+++ b/Sources/libgir2swift/gir+swift.swift
@@ -1297,6 +1297,8 @@ public func recordClassCode(_ e: GIR.Record, parent: String, indentation: String
     let noSignals = noProperties && signals.isEmpty
     let retain: String
     let retainPtr: String
+	// Disable required initalisers for Value wrappers. AppLaunchContext is hardcoded because of a bug that causes it to report a wrong base when generating gdk wrappers.
+	let isObject = e.rootType.name == "Object" || e.rootType.name == "AppLaunchContext";
     if let ref = e.ref, ref.args.count == 1 {
         retain = ref.cname
         retainPtr = RawPointerConversion(source: cGIRType, target: GIR.rawPointerType).castFromTarget(expression: "ptr")
@@ -1426,14 +1428,14 @@ public func recordClassCode(_ e: GIR.Record, parent: String, indentation: String
         "/// Unsafe untyped initialiser.\n" + indentation +
         "/// **Do not use unless you know the underlying data type the pointer points to conforms to `\(protocolName)`.**\n" + indentation +
         "/// - Parameter p: raw pointer to the underlying object\n" + indentation + "@inlinable " +
-        (hasParent ? "override " : "") +
+						(hasParent ? "override " : "") +
         "public init(raw p: UnsafeRawPointer) {\n" + doubleIndentation +
             (hasParent ? "super.init(raw: p)\n" : "ptr = UnsafeMutableRawPointer(mutating: p)\n") + indentation +
         "}\n\n") + (indentation +
 
         "/// Unsafe untyped, retaining initialiser.\n" + indentation +
         "/// **Do not use unless you know the underlying data type the pointer points to conforms to `\(protocolName)`.**\n" + indentation + "@inlinable " +
-        (hasParent ? "override " : "") +
+						(hasParent ? "override " : "") +
         "public init(retainingRaw raw: UnsafeRawPointer) {\n" + doubleIndentation +
             (hasParent ? "super.init(retainingRaw: raw)\n" :
             "ptr = UnsafeMutableRawPointer(mutating: raw)\n" + doubleIndentation +
@@ -1443,7 +1445,7 @@ public func recordClassCode(_ e: GIR.Record, parent: String, indentation: String
         "/// Unsafe untyped initialiser.\n" + indentation +
         "/// **Do not use unless you know the underlying data type the pointer points to conforms to `\(protocolName)`.**\n" + indentation +
         "/// - Parameter p: mutable raw pointer to the underlying object\n" + indentation + "@inlinable " +
-        (hasParent ? "override " : "") +
+						(hasParent ? "override " : "") +
         "public init(raw p: UnsafeMutableRawPointer) {\n" + doubleIndentation +
             (hasParent ? "super.init(raw: p)\n" : "ptr = p\n") + indentation +
         "}\n\n") + (indentation +
@@ -1451,7 +1453,8 @@ public func recordClassCode(_ e: GIR.Record, parent: String, indentation: String
         "/// Unsafe untyped, retaining initialiser.\n" + indentation +
         "/// **Do not use unless you know the underlying data type the pointer points to conforms to `\(protocolName)`.**\n" + indentation +
         "/// - Parameter raw: mutable raw pointer to the underlying object\n" + indentation + "@inlinable " +
-        (hasParent ? "override " : "") +
+		// We add required to this initialiser on objects so that it can be used to instantiate generic types constrained to a subclass of object.
+						(isObject ? "required ": hasParent ? "override ": "") +
         "public init(retainingRaw raw: UnsafeMutableRawPointer) {\n" + doubleIndentation +
             (hasParent ? "super.init(retainingRaw: raw)\n" :
             "ptr = raw\n" + doubleIndentation +


### PR DESCRIPTION
This pull request modifies the code generation so that the initialiser from an UnsafeMutableRawPointer is required for GObject-derived classes. This allows type appropriate objects to be generated from generic contexts. This does mean custom classes need to implement this initialiser, but I think the added functionality is worthwhile.