### PR TITLE
Add experimental support for SE-0303 package plugins

### DIFF
--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -1,0 +1,40 @@
+// swift-tools-version:5.5
+
+import PackageDescription
+
+let pkgName = "gir2swift"
+let libTarget = "lib\(pkgName)"
+
+let package = Package(
+    name: pkgName,
+    products: [
+        .executable(name: pkgName, targets: [pkgName]),
+        .library(name: libTarget, targets: [libTarget]),
+        .plugin(name: "Gir2SwiftPlugin", targets: ["Gir2SwiftPlugin"])
+    ],
+    dependencies: [ 
+        .package(url: "https://github.com/rhx/SwiftLibXML.git", .branch("main")),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.4.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: pkgName, 
+            dependencies: [
+                .init(stringLiteral: libTarget)
+            ]
+        ),
+        .target(
+            name: libTarget,
+            dependencies: [
+                .init(stringLiteral: "SwiftLibXML"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ]
+        ),
+        .plugin(
+            name: "Gir2SwiftPlugin",
+            capability: .buildTool(),
+            dependencies: ["gir2swift"]
+        ),
+        .testTarget(name: "\(pkgName)Tests", dependencies: [.init(stringLiteral: libTarget)]),
+    ]
+)

--- a/Sources/Gir2SwiftPlugin/plugin.swift
+++ b/Sources/Gir2SwiftPlugin/plugin.swift
@@ -1,0 +1,70 @@
+import Foundation
+import PackagePlugin
+
+extension Path {
+    func exists() -> Bool {
+        FileManager.default.fileExists(atPath: string)
+    }
+}
+
+let module = targetBuildContext.moduleName
+let outputDir = targetBuildContext.outputDirectory.appending("Generated")
+
+let output = outputDir.appending("Output.swift")
+
+func packageDirectory(for target: Path) -> Path {
+    var curr = target
+    while !curr.appending("Package.swift").exists() {
+        if curr.stem.isEmpty {
+            fatalError("Could not find Package.swift for target \(target)")
+        }
+        curr = curr.removingLastComponent()
+    }
+    return curr
+}
+
+let girNames = try targetBuildContext.dependencies.compactMap { target -> String? in
+    let package = packageDirectory(for: target.targetDirectory)
+    let manifest = package.appending("gir2swift-manifest.sh")
+    guard manifest.exists() else { return nil }
+
+    let pipe = Pipe()
+
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: manifest.string)
+    proc.arguments = ["gir-name"]
+    proc.standardOutput = pipe
+    try proc.run()
+
+    return String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+let girSearchPaths: [Path] = ["/opt/homebrew/share/gir-1.0", "/usr/local/share/gir-1.0", "/usr/share/gir-1.0"]
+guard let girPath = girSearchPaths.first(where: { searchPath in
+    girNames.allSatisfy { gir in searchPath.appending("\(gir).gir").exists() }
+}) else {
+    fatalError("Could not locate GIR path")
+}
+
+let girFiles = girNames.map { girPath.appending("\($0).gir") }
+
+commandConstructor.createBuildCommand(
+    displayName: "Running gir2swift",
+    executable: targetBuildContext.packageDirectory.appending("gir2swift-manifest.sh"),
+    arguments: [
+        "generate",
+        // packagePath
+        targetBuildContext.packageDirectory.string,
+        // g2s_exec
+        try targetBuildContext.tool(named: "gir2swift").path.string,
+        // gir_pre
+        girNames.dropFirst().joined(separator: " "),
+        // gir_path
+        girPath.string,
+        // output_dir
+        outputDir.string
+    ],
+    inputFiles: girFiles,
+    outputFiles: [output]
+)


### PR DESCRIPTION
This PR adds support for Package Plugins, which as of Swift 5.5(ish) are the official way to dynamically generate source files. Plugins are currently experimental, and SPM currently requires setting `SWIFTPM_ENABLE_PLUGINS=1` to enable them. Accordingly, this PR is a draft until plugins are enabled by default.

In order for dependent packages to implement plugin support, they need to add `plugins: [.plugin(name: "Gir2SwiftPlugin", package: "gir2swift")]` to their target. Additionally, they must update their manifest's generate command to accept an optional output directory argument; the entire output needs to be written to `<output_dir>/Output.swift`.

I've created a sample implementation in https://github.com/kabiroberai/SwiftGLib/commit/7bbbeabd5604ad1859137c6516ccb93b55727535. I do think it's worth discussing refining the manifest to be more efficient and better suited to SPM plugins: for example, it would be more efficient if the plugin didn't have to invoke a script just to read the GIR file name.