### PR TITLE
YAML manifest and internal .gir search

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/.build/debug/gir2swift",
             "cwd": "${workspaceFolder}/../SwiftGtk",
-            "args": ["-o", "Sources/Gtk", "-s", ""]
+            "args": ["-o", "Sources/Gtk"]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,9 @@
             "name": "Launch",
             "type": "lldb",
             "request": "launch",
-            "program": "${workspaceFolder}/.build/debug/${workspaceFolderBasename}",
-            "cwd": "${workspaceFolder}/../test-SwiftGtk",
-            "args": ["-o", "Sources/Gtk", "-s", "-m", "Gtk-3.0.module", "-p", "/usr/share/gir-1.0/Atk-1.0.gir", "-p", "/usr/share/gir-1.0/cairo-1.0.gir", "-p", "/usr/share/gir-1.0/Gdk-3.0.gir", "-p", "/usr/share/gir-1.0/GdkPixbuf-2.0.gir", "-p", "/usr/share/gir-1.0/Gio-2.0.gir", "-p", "/usr/share/gir-1.0/GLib-2.0.gir", "-p", "/usr/share/gir-1.0/GModule-2.0.gir", "-p", "/usr/share/gir-1.0/GObject-2.0.gir", "-p", "/usr/share/gir-1.0/Pango-1.0.gir", "-p", "/usr/share/gir-1.0/PangoCairo-1.0.gir", "/usr/share/gir-1.0/Gtk-3.0.gir"]
+            "program": "${workspaceFolder}/.build/debug/gir2swift",
+            "cwd": "${workspaceFolder}/../SwiftGtk",
+            "args": ["-o", "Sources/Gtk", "-s", ""]
         }
     ]
 }

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         .library(name: libTarget, targets: [libTarget]),
     ],
     dependencies: [ 
+        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),
         .package(url: "https://github.com/rhx/SwiftLibXML.git", .branch("main")),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.4.0")
     ],
@@ -25,8 +26,9 @@ let package = Package(
         .target(
             name: libTarget,
             dependencies: [
-                .init(stringLiteral: "SwiftLibXML"),
-                .product(name: "ArgumentParser", package: "swift-argument-parser")
+                "SwiftLibXML",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                "Yams"
             ]
         ),
         .testTarget(name: "\(pkgName)Tests", dependencies: [.init(stringLiteral: libTarget)]),

--- a/Sources/libgir2swift/models/Gir2Swift.swift
+++ b/Sources/libgir2swift/models/Gir2Swift.swift
@@ -31,7 +31,7 @@ public struct Gir2Swift: ParsableCommand {
     var postProcess: [String] = []
 
     /// Array of names of pre-parsed `.gir` files.
-    @Option(name: .short, help: "Add pre-requisite .gir files to ensure the types in file.gir are known.")
+    @Option(name: .short, help: "Add pre-requisite .gir files to ensure the types in file.gir are known. Prerequisities specified in CLI are merged with the prerequisities found by gir2swift.")
     var prerequisiteGir: [String] = []
 
     /// Name of the output directory to write generated files to.
@@ -41,18 +41,19 @@ public struct Gir2Swift: ParsableCommand {
 
     /// Name of the library to pass to pkg-config
     /// - Note: Defaults to the lower-cased name of the `.gir` file
-    @Option(name: .long, help: "Library name to pass to pkg-config.")
+    @Option(name: .long, help: "Library name to pass to pkg-config. Pkg config name specified in CLI trumps the one found in manifest.")
     var pkgConfigName: String?
 
     /// File containing one-off boilerplate code for your module
     @Option(name: .short, help: "Add the given .swift file as the main (hand-crafted) Swift file for your library target.")
     var moduleBoilerPlateFile: String = ""
 
-    @Option(name: .long, help: "Custom path to manifest")
+    /// By default, the gir2swift searches for manifest in the work directory. As for now, the search can't be sidabled.
+    @Option(name: .long, help: "Custom path to manifest.")
     var manifest: String = "gir2swift-manifest.yaml"
 
     /// The actual, main `.gir` file(s) to process
-    @Argument(help: "The .gir metadata files to process.")
+    @Argument(help: "The .gir metadata files to process. Gir files specified in CLI are merged with those specified in the manifest.")
     var girFiles: [String] = []
 
 
@@ -79,7 +80,6 @@ public struct Gir2Swift: ParsableCommand {
         // This variable is a dead store
         var pkgConfig = pkgConfigName
 
-        // TODO: Make planning nicer
         do {
             if let wd = getcwd(), let manifestUrl = URL(string: wd)?.appendingPathComponent(manifest) {
                 let plan = try Plan(using: manifestUrl) 

--- a/Sources/libgir2swift/utilities/System.swift
+++ b/Sources/libgir2swift/utilities/System.swift
@@ -141,7 +141,7 @@ func run(standardInput: Any? = nil, standardOutput: Any? = nil, standardError: A
         process.waitUntilExit()
         return Int(process.terminationStatus)
     } catch {
-        perror("Cannot run \(command)")
+        print("Cannot run \(command)", to: &Streams.stdErr)
         return nil
     }
 }

--- a/Sources/libgir2swift/utilities/System.swift
+++ b/Sources/libgir2swift/utilities/System.swift
@@ -174,9 +174,9 @@ func test(standardInput: Any? = nil, standardOutput: Any? = nil, standardError: 
 
 func executeAndWait(_ program: String, arguments: [String]) throws -> String? {
     let stdOut = Pipe()
-    let code = run(standardOutput: stdOut, program, arguments: arguments)
+    let optCode = run(standardOutput: stdOut, program, arguments: arguments)
 
-    guard let code = code else {
+    guard let code = optCode else {
         throw ProcessError.couldNotBeSpawned
     }
 

--- a/Sources/libgir2swift/utilities/System.swift
+++ b/Sources/libgir2swift/utilities/System.swift
@@ -13,6 +13,17 @@ protocol IOHandle {}
 extension Pipe: IOHandle {}
 extension FileHandle: IOHandle {}
 
+enum ProcessError: Error {
+    case endedWith(code: Int)
+    case couldNotBeSpawned
+}
+
+private extension ProcessInfo {
+    var environmentPaths: [String]? {
+        environment["PATH"].flatMap { $0.split(separator: ":", omittingEmptySubsequences: true) }?.map(String.init)
+    }
+}
+
 /// A structure representing a shell comand and its arguments
 struct CommandArguments {
     /// Name of the shell comand
@@ -35,7 +46,7 @@ func getcwd() -> String? {
 ///   - executable: The executable to search for
 ///   - path: The array of directories to search in (defaults to the contents of the `PATH` environment variable)
 /// - Returns: a `URL` representing the full path of the executable if successful, `nil` otherwise
-func urlForExecutable(named executable: String, in path: [String] = ProcessInfo.processInfo.environment["PATH"].map { $0.split(separator: ":").map(String.init) } ?? []) -> URL? {
+func urlForExecutable(named executable: String, in path: [String] = ProcessInfo.processInfo.environmentPaths ?? []) -> URL? {
     guard let wd = getcwd().map(URL.init(fileURLWithPath:)) else { return nil }
     let fm = FileManager.default
     for url in path.map({ URL(string: $0, relativeTo: wd) ?? URL(fileURLWithPath: $0) }) {
@@ -66,7 +77,7 @@ func urlForExecutable(named executable: String, in path: [String] = ProcessInfo.
 ///   - standardError: the pipe to redirect standard error to if not `nil`
 /// - Throws: an error if the command cannot be run
 /// - Returns: The process being executed.  Call `run()` and then `waitUntilExit()` on the process to collect its `terminationStatus`
-func createProcess(command: String, in path: [String] = ProcessInfo.processInfo.environment["PATH"].map { $0.split(separator: ":").map(String.init) } ?? [], arguments: [String] = [], standardInput: Any? = nil, standardOutput: Any? = nil, standardError: Any? = nil) throws -> Process {
+func createProcess(command: String, in path: [String] = ProcessInfo.processInfo.environmentPaths ?? [], arguments: [String] = [], standardInput: Any? = nil, standardOutput: Any? = nil, standardError: Any? = nil) throws -> Process {
     guard let url = urlForExecutable(named: command, in: path) else {
         throw POSIXError(.ENOENT)
     }
@@ -90,7 +101,7 @@ func createProcess(command: String, in path: [String] = ProcessInfo.processInfo.
 ///   - output: the FileHandle to redirect standard output to if not `nil`
 /// - Throws: an error if any of the commands cannot be run
 /// - Returns: an array of processes being executed
-func pipe(_ components: [CommandArguments], in path: [String] = ProcessInfo.processInfo.environment["PATH"].map { $0.split(separator: ":").map(String.init) } ?? [], input: Any? = nil, output: Any? = nil) throws -> [Process] {
+func pipe(_ components: [CommandArguments], in path: [String] = ProcessInfo.processInfo.environmentPaths ?? [], input: Any? = nil, output: Any? = nil) throws -> [Process] {
     let pipes: [Any?] = components.enumerated().map { $0.offset == 0 ? input : Pipe() as Any? } + [output]
     let processes = try components.enumerated().map {
         try createProcess(command: $0.element.command, in: path, arguments: $0.element.arguments, standardInput: pipes[$0.offset], standardOutput: pipes[$0.offset+1])
@@ -115,7 +126,13 @@ func pipe(_ components: [CommandArguments], in path: [String] = ProcessInfo.proc
 @discardableResult
 func run(standardInput: Any? = nil, standardOutput: Any? = nil, standardError: Any? = nil, _ command: String, arguments: [String]) -> Int? {
     do {
-        let process = try createProcess(command: command, arguments: arguments)
+        let process = try createProcess(
+            command: command, 
+            arguments: arguments, 
+            standardInput: standardInput, 
+            standardOutput: standardOutput, 
+            standardError: standardError
+        )
         if #available(macOS 10.13, *) {
             try process.run()
         } else {
@@ -153,4 +170,22 @@ func test(standardInput: Any? = nil, standardOutput: Any? = nil, standardError: 
         }
     }
     return rv == expectedResult
+}
+
+func executeAndWait(_ program: String, arguments: [String]) throws -> String? {
+    let stdOut = Pipe()
+    let code = run(standardOutput: stdOut, program, arguments: arguments)
+
+    guard let code = code else {
+        throw ProcessError.couldNotBeSpawned
+    }
+
+    guard code == 0 else {
+        throw ProcessError.endedWith(code: code)
+    }
+
+    return String(
+        data: stdOut.fileHandleForReading.readDataToEndOfFile(),
+        encoding: .utf8
+    )?.trimmingCharacters(in: .whitespacesAndNewlines)
 }

--- a/Sources/libgir2swift/utilities/System.swift
+++ b/Sources/libgir2swift/utilities/System.swift
@@ -141,7 +141,7 @@ func run(standardInput: Any? = nil, standardOutput: Any? = nil, standardError: A
         process.waitUntilExit()
         return Int(process.terminationStatus)
     } catch {
-        print("Cannot run \(command)", to: &Streams.stdErr)
+        print("Cannot run \(command) with error: \(error)", to: &Streams.stdErr)
         return nil
     }
 }
@@ -172,6 +172,12 @@ func test(standardInput: Any? = nil, standardOutput: Any? = nil, standardError: 
     return rv == expectedResult
 }
 
+/// Executes desired program and
+/// - Parameters:
+///   - program: The name of the program
+///   - arguments: List of arguments
+/// - Throws: Throws in case, that the process could not be executed or returned non-zero code.
+/// - Returns: The contents of std-out
 func executeAndWait(_ program: String, arguments: [String]) throws -> String? {
     let stdOut = Pipe()
     let optCode = run(standardOutput: stdOut, program, arguments: arguments)

--- a/Sources/libgir2swift/utilities/planning.swift
+++ b/Sources/libgir2swift/utilities/planning.swift
@@ -1,5 +1,7 @@
 import Foundation
+import FoundationNetworking
 import Yams
+import SwiftLibXML
 
 struct Manifest: Codable {
     private enum CodingKeys: String, CodingKey {
@@ -10,33 +12,47 @@ struct Manifest: Codable {
 
     let version: UInt
     let girName: String
-    let pkgConfig: String?
+    let pkgConfig: String
+}
+
+struct GirPackageMetadata {
+    struct Dependency {
+        let name: String
+        let version: String
+
+        var girName: String { name + "-" + version }
+    }
+
+    let pkgName: String
+    let dependency: [Dependency]
 }
 
 struct Plan {
 
     enum Error: Swift.Error {
-        case girNotFound, girPrerequisityNotFound(named: String)
+        case girNotFound(named: String)
+        case girParsingFailed
     }
 
     let girFileToGenerate: URL
     let girFilesToPreload: [URL]
-    let pkgConfigName: String?
+    let pkgConfigName: String
 
-    init(using manifest: URL) throws {
-        let data = try Data.init(contentsOf: manifest)
+    init(using manifestUrl: URL) throws {
+        // From some reason, Data would not provide correct result
+        let data = try String.init(contentsOfFile: manifestUrl.path)
         let manifest = try YAMLDecoder().decode(Manifest.self, from: data)
         
         let girPath = try Plan.searchForGir(
             named: manifest.girName, 
-            pkgConfig: manifest.pkgConfig.flatMap {[$0]} ?? []
+            pkgConfig: [manifest.pkgConfig]
         )
         guard let girPath = girPath else {
-            throw Error.girNotFound
+            throw Error.girNotFound(named: manifest.girName + ".gir" )
         } 
 
         self.girFileToGenerate = girPath
-        self.girFilesToPreload = try Plan.loadPrerequisities(from: girPath)
+        self.girFilesToPreload = try Plan.loadPrerequisities(from: girPath, pkgConfig: manifest.pkgConfig)
         self.pkgConfigName = manifest.pkgConfig
     }
 
@@ -60,12 +76,119 @@ struct Plan {
 
 
         return searchPaths
-            .map { $0.appendingPathComponent(name).appendingPathExtension(".gir") }
-            .first { FileManager.default.fileExists(atPath: $0.path) }
+            .map { $0.appendingPathComponent(name).appendingPathExtension("gir") }
+            .first { 
+                FileManager.default.fileExists(atPath: $0.path) 
+            }
     }
 
-    private static func loadPrerequisities(from gir: URL) throws -> [URL] {
+    private static func loadPrerequisities(from gir: URL, pkgConfig: String) throws -> [URL] {
+        var explored: [String: URL] = [ gir.deletingLastPathComponent().lastPathComponent : gir ]
+        var toExplore: Set<String> = Set(try parsePackageInfo(for: gir).dependency.map(\.girName))
 
-        return []
+        let pkgConfigCandidates: [String]
+        #if os(macOS)
+            pkgConfigCandidates = try getAllPkgConfigDependencies(for: pkgConfig)
+        #else
+            pkgConfigCandidates = []
+        #endif
+
+        
+
+        while true {
+            if toExplore.isEmpty {
+                break
+            }
+
+            let executing = toExplore.removeFirst()
+            guard let url = try searchForGir(named: executing, pkgConfig: pkgConfigCandidates) else {
+                throw Error.girNotFound(named: executing)
+            }
+
+            explored[executing] = url
+
+            let packageInfo = try parsePackageInfo(for: url)
+            packageInfo.dependency.forEach { dependency in
+                if explored[dependency.girName] == nil {
+                    toExplore.insert(dependency.girName)
+                }
+            }
+        }
+
+        return Array(explored.values)
+    }
+
+    private static func getAllPkgConfigDependencies(for package: String) throws -> [String] {
+        var explored: Set<String> = []
+        var toExplore: Set<String> = [package]
+
+        while true {
+            if toExplore.isEmpty {
+                break
+            }
+
+            let executing = toExplore.removeFirst()
+            explored.insert(executing)
+
+            try getPkgConfigDependencies(for: executing).forEach { result in
+                if !explored.contains(result) {
+                    toExplore.insert(result)
+                }
+            }
+        }
+
+        return Array(explored)
+    }
+
+    private static func getPkgConfigDependencies(for package: String) throws -> [String] {
+        guard let output = try executeAndWait("pkg-config", arguments: ["--print-requires", package]) else {
+            return []
+        }
+
+        let dependecyRecord = output.components(separatedBy: .newlines)
+        let packageNames = dependecyRecord.compactMap { line in
+            line.components(separatedBy: .whitespaces).first
+        }
+
+        return packageNames
+    }
+
+    private static func parsePackageInfo(for gir: URL) throws -> GirPackageMetadata {
+        guard let xml = XMLDocument(fromFile: gir.path) else {
+            throw Error.girNotFound(named: gir.lastPathComponent)
+        }
+
+        // @rhx please check this code
+        if let repository = xml.first(where: { $0.name == "repository" }) {
+            let namespaces = repository.namespaces
+
+            guard 
+                let packageName = xml.xpath(
+                    "/gir:repository/gir:package", 
+                    namespaces: namespaces, 
+                    defaultPrefix: "gir"
+                )?.first?.attribute(named: "name") 
+            else { throw Error.girParsingFailed }
+
+            let dependencies = xml.xpath(
+                "/gir:repository/gir:include", 
+                namespaces: namespaces, 
+                defaultPrefix: "gir"
+            )?.lazy.compactMap { node -> GirPackageMetadata.Dependency? in
+                guard
+                    let name = node.attribute(named: "name"),
+                    let version = node.attribute(named: "version")
+                else { return nil }
+                return GirPackageMetadata.Dependency(name: name, version: version)
+            }
+
+            return GirPackageMetadata(
+                pkgName: packageName,
+                dependency: dependencies.flatMap(Array.init(_:)) ?? []
+            )
+
+        }
+
+        throw Error.girParsingFailed
     }
 }

--- a/Sources/libgir2swift/utilities/planning.swift
+++ b/Sources/libgir2swift/utilities/planning.swift
@@ -54,11 +54,11 @@ struct Plan {
         let data = try String.init(contentsOfFile: manifestUrl.path)
         let manifest = try YAMLDecoder().decode(Manifest.self, from: data)
         
-        let girPath = try Plan.searchForGir(
+        let optGirPath = try Plan.searchForGir(
             named: manifest.girName, 
             pkgConfig: [manifest.pkgConfig]
         )
-        guard let girPath = girPath else {
+        guard let girPath = optGirPath else {
             throw Error.girNotFound(named: manifest.girName + ".gir" )
         } 
 

--- a/Sources/libgir2swift/utilities/planning.swift
+++ b/Sources/libgir2swift/utilities/planning.swift
@@ -68,7 +68,7 @@ struct Plan {
     }
 
     private static func searchForGir(named name: String, pkgConfig: Set<String>) throws -> URL? {
-        let defaultPaths = ["/opt/homebrew/share/gir-1.0", "/usr/local/share/gir-1.0", "/usr/share/gir-1.0"].map { URL.init(fileURLWithPath: $0, isDirectory: false) }
+        let defaultPaths = ["/opt/homebrew/share/gir-1.0", "/usr/local/share/gir-1.0", "/usr/share/gir-1.0"].map { URL(fileURLWithPath: $0, isDirectory: false) }
 
         #if os(macOS)
         let homebrewRelativeGirLocation = "../share/gir-1.0/"
@@ -98,17 +98,13 @@ struct Plan {
         var toExplore: Set<String> = Set(try parsePackageInfo(for: gir).dependency.map(\.girName) + (prerequisities?.map(\.girName) ?? []))
 
         var pkgConfigCandidates: Set<String> = []
-        #if !os(macOS)
+        #if os(macOS)
             for package in (prerequisities?.map(\.pkgConfig) ?? []) + [pkgConfig] {
                 pkgConfigCandidates.formUnion(try getAllPkgConfigDependencies(for: package))
             }
         #endif
 
-        while true {
-            if toExplore.isEmpty {
-                break
-            }
-
+        while !toExplore.isEmpty {
             let executing = toExplore.removeFirst()
             guard let url = try searchForGir(named: executing, pkgConfig: pkgConfigCandidates) else {
                 throw Error.girNotFound(named: executing)
@@ -131,11 +127,7 @@ struct Plan {
         var explored: Set<String> = []
         var toExplore: Set<String> = [package]
 
-        while true {
-            if toExplore.isEmpty {
-                break
-            }
-
+        while !toExplore.isEmpty {
             let executing = toExplore.removeFirst()
             explored.insert(executing)
 
@@ -159,7 +151,7 @@ struct Plan {
             line.components(separatedBy: .whitespaces).first
         }
 
-        return packageNames
+        return packageNames.filter { !$0.isEmpty }
     }
 
     private static func parsePackageInfo(for gir: URL) throws -> GirPackageMetadata {

--- a/Sources/libgir2swift/utilities/planning.swift
+++ b/Sources/libgir2swift/utilities/planning.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Yams
+
+struct Manifest: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case girName = "gir-name"
+        case pkgConfig = "pkg-config"
+    }
+
+    let version: UInt
+    let girName: String
+    let pkgConfig: String?
+}
+
+struct Plan {
+
+    enum Error: Swift.Error {
+        case girNotFound, girPrerequisityNotFound(named: String)
+    }
+
+    let girFileToGenerate: URL
+    let girFilesToPreload: [URL]
+    let pkgConfigName: String?
+
+    init(using manifest: URL) throws {
+        let data = try Data.init(contentsOf: manifest)
+        let manifest = try YAMLDecoder().decode(Manifest.self, from: data)
+        
+        let girPath = try Plan.searchForGir(
+            named: manifest.girName, 
+            pkgConfig: manifest.pkgConfig.flatMap {[$0]} ?? []
+        )
+        guard let girPath = girPath else {
+            throw Error.girNotFound
+        } 
+
+        self.girFileToGenerate = girPath
+        self.girFilesToPreload = try Plan.loadPrerequisities(from: girPath)
+        self.pkgConfigName = manifest.pkgConfig
+    }
+
+    private static func searchForGir(named name: String, pkgConfig: [String]) throws -> URL? {
+        let defaultPaths = ["/opt/homebrew/share/gir-1.0", "/usr/local/share/gir-1.0", "/usr/share/gir-1.0"].map { URL.init(fileURLWithPath: $0, isDirectory: false) }
+
+        #if os(macOS)
+        let homebrewRelativeGirLocation = "../share/gir-1.0/"
+        let homebrewPaths = pkgConfig.compactMap { pkgName -> URL? in 
+            let libDir = try? executeAndWait("pkg-config", arguments: ["--variable=libdir", pkgName])
+            return libDir.flatMap { 
+                let libDirUrl = URL(fileURLWithPath: $0, isDirectory: true)
+                return URL(string: homebrewRelativeGirLocation, relativeTo: libDirUrl)
+            }
+        }
+
+        let searchPaths = homebrewPaths + defaultPaths
+        #else
+        let searchPaths = defaultPaths
+        #endif
+
+
+        return searchPaths
+            .map { $0.appendingPathComponent(name).appendingPathExtension(".gir") }
+            .first { FileManager.default.fileExists(atPath: $0.path) }
+    }
+
+    private static func loadPrerequisities(from gir: URL) throws -> [URL] {
+
+        return []
+    }
+}

--- a/Sources/libgir2swift/utilities/planning.swift
+++ b/Sources/libgir2swift/utilities/planning.swift
@@ -2,16 +2,7 @@ import Foundation
 import Yams
 import SwiftLibXML
 
-struct Prerequisity: Codable {
-    private enum CodingKeys: String, CodingKey {
-        case girName = "gir-name"
-        case pkgConfig = "pkg-config"
-    }
-    
-    let girName: String
-    let pkgConfig: String
-}
-
+/// Declaration of the manifest contents.
 struct Manifest: Codable {
     private enum CodingKeys: String, CodingKey {
         case version
@@ -20,12 +11,34 @@ struct Manifest: Codable {
         case prerequisities
     }
 
+    /// The version of manifest. It is not utilized now, but I want to keep the property there for future purposes.
     let version: UInt
+    
+    /// The name of the gir file associated with the manifest. Extension is NOT expected.
     let girName: String
+    
+    /// The name of pkg-config package in which the gir file resides (mainly for the purposes of macOS sandboxing)
     let pkgConfig: String
+    
+    /// Optional list of `.gir` prerequisities
     let prerequisities: [Prerequisity]?
 }
 
+/// Description of a `.gir` prerequisity
+struct Prerequisity: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case girName = "gir-name"
+        case pkgConfig = "pkg-config"
+    }
+
+    /// Gir file name associated with the prerequisity. Extension is NOT expected.
+    let girName: String
+
+    /// The name of pkg-config package in which the gir file resides (mainly for the purposes of macOS sandboxing)
+    let pkgConfig: String
+}
+
+/// Metadata parsed from a `.gir` file. This structure is intended to help in determining the dependency graph of `.gir` files. It represents the contents of `/gir:repository`
 struct GirPackageMetadata {
     struct Dependency {
         let name: String
@@ -34,10 +47,14 @@ struct GirPackageMetadata {
         var girName: String { name + "-" + version }
     }
 
+    /// Package name corresponding to `pkg-config`. Represents the contents of `/gir:repository/gir:package`
     let pkgName: String
+    
+    ///Dependency required for preload before generation if this `.gir` file. Represents the contents of `/gir:repository/gir:include`
     let dependency: [Dependency]
 }
 
+/// Structure, that is used to determine generation process.
 struct Plan {
 
     enum Error: Swift.Error {
@@ -45,15 +62,35 @@ struct Plan {
         case girParsingFailed
     }
 
+    /// The path to `.gir` file that shall be generated
     let girFileToGenerate: URL
-    let girFilesToPreload: [URL]
-    let pkgConfigName: String
 
+    /// The paths to prerequisities of the `.gir` file
+    let girFilesToPreload: [URL]
+    
+    /// Pkg config name of the generated package
+    let pkgConfigName: String
+    
+    /// Creates generation plan by reading `.yaml` manifest. The strucuture of the manifest is
+    /// described by structure `Manifest`.
+    ///
+    /// After contents of the `.yaml` are parsed, the initializer then parses the `.gir` files and
+    /// consults `pkg-config` in order to determine the dependency graph of the `.gir` files
+    /// and their location.
+    ///
+    /// - Note: On macOS, the `.gir` files are located in separate folders, therefore we need
+    /// to consult the `pkg-config` out of necessity, because this is the only way we can learn the
+    /// potential location of the gir files.
+    ///
+    /// - Parameter manifestUrl: Path to manifest
+    /// - Throws: Error may represent various error states, differing from the inability to read
+    /// the `.yaml` file, a `.gir` file or error during consulting `pkg-config`.
     init(using manifestUrl: URL) throws {
-        // From some reason, Data would not provide correct result
+        // For some reason `swift-corelibs-foundation` failed to open the file as a `Data`.
         let data = try String.init(contentsOfFile: manifestUrl.path)
         let manifest = try YAMLDecoder().decode(Manifest.self, from: data)
         
+        // Search for location of the generated `.gir` file.
         let optGirPath = try Plan.searchForGir(
             named: manifest.girName, 
             pkgConfig: [manifest.pkgConfig]
@@ -66,12 +103,22 @@ struct Plan {
         self.girFilesToPreload = try Plan.loadPrerequisities(from: girPath, pkgConfig: manifest.pkgConfig, prerequisities: manifest.prerequisities)
         self.pkgConfigName = manifest.pkgConfig
     }
-
+    
+    /// Searches for `.gir` file location for given name.
+    /// - Parameters:
+    ///   - name: The name of the `.gir` file WITHOUT extension
+    ///   - pkgConfig: Names of pkg-config packages that should be explored too. This is done on macOS only.
+    /// - Returns: Location of the `.gir` file, if found.
     private static func searchForGir(named name: String, pkgConfig: Set<String>) throws -> URL? {
+        // Common locations of `.gir` files on different platforms
         let defaultPaths = ["/opt/homebrew/share/gir-1.0", "/usr/local/share/gir-1.0", "/usr/share/gir-1.0"].map { URL(fileURLWithPath: $0, isDirectory: false) }
-
+        
+        var searchPaths = defaultPaths
         #if os(macOS)
+        // Path relative to the `libdir` variable of the package, where the `.gir` files are commonly located. This path is arbitrary!
         let homebrewRelativeGirLocation = "../share/gir-1.0/"
+        // All pkg-config packages passed in the argument are scanned and their `libdir` values are reported.
+        // TODO: This is major performance hit. Optimization desirable.
         let homebrewPaths = pkgConfig.compactMap { pkgName -> URL? in 
             let libDir = try? executeAndWait("pkg-config", arguments: ["--variable=libdir", pkgName])
             return libDir.flatMap { 
@@ -80,38 +127,56 @@ struct Plan {
             }
         }
 
-        let searchPaths = homebrewPaths + defaultPaths
-        #else
-        let searchPaths = defaultPaths
+        searchPaths = homebrewPaths + defaultPaths
         #endif
 
-
+        // After all search paths are determined, we search for the first appearance of a `.gir` file with corresponding name.
         return searchPaths
             .map { $0.appendingPathComponent(name).appendingPathExtension("gir") }
             .first { 
                 FileManager.default.fileExists(atPath: $0.path) 
             }
     }
-
+    
+    /// This function the overall driver of the dependency graph generation. It searches the `pkg-config` dependency
+    /// graph to get all required `pkg-config` packages which may contain a `.gir` file and then parses the `.gir`
+    /// files in order to get list of all names of `.gir` files that will be required. If a location of any `.gir` file can not be
+    /// determined, the functions throws an error.
+    ///
+    /// - Parameters:
+    ///   - gir: Path to root gir file.
+    ///   - pkgConfig: Name of `pkg-config` package which corresponds to the root `.gir` file.
+    ///   - prerequisities: Additional prerequisites alongside with their `pkg-config` package names specified in the manifest.
+    /// - Returns: List of locations of `.gir` files that have to be preloaded.
     private static func loadPrerequisities(from gir: URL, pkgConfig: String, prerequisities: [Prerequisity]?) throws -> [URL] {
+        // We do not want to list the root `.gir` file as explored, since it is not it's own dependency. (Having the gir file in the list would break the generation process.)
         var explored: [String: URL] = [:]
+        // The root `.gir` file is parsed and it's dependencies are scheduled for exploration. Also any prerequisited are scheduled for exploration.
         var toExplore: Set<String> = Set(try parsePackageInfo(for: gir).dependency.map(\.girName) + (prerequisities?.map(\.girName) ?? []))
 
+        // This set is used to store names of `pkg-config` packages, that may contain a `.gir` file.
+        // This is needed only on macOS since it is the only supported platform where the `.gir`
+        // files are not located in a single directory.
         var pkgConfigCandidates: Set<String> = []
         #if os(macOS)
+            // Determine the dependency graph of `pkg-config` and add them all to the candidate set.
             for package in (prerequisities?.map(\.pkgConfig) ?? []) + [pkgConfig] {
                 pkgConfigCandidates.formUnion(try getAllPkgConfigDependencies(for: package))
             }
         #endif
 
+        // Continue parsing `.gir` files and search their dependencies, until no more are to be
+        // searched.
         while !toExplore.isEmpty {
             let executing = toExplore.removeFirst()
+            // If a `.gir` file can not be found, end.
             guard let url = try searchForGir(named: executing, pkgConfig: pkgConfigCandidates) else {
                 throw Error.girNotFound(named: executing)
             }
 
             explored[executing] = url
 
+            // Add all `.gir` files that were not already explored to the exploration list.
             let packageInfo = try parsePackageInfo(for: url)
             packageInfo.dependency.forEach { dependency in
                 if explored[dependency.girName] == nil {
@@ -120,20 +185,29 @@ struct Plan {
             }
         }
 
+        // Ensure, that the root `.gir` file is not listed as it's own dependency. This
+        // step might be needed, in case that circular dependency is present.
         return explored
             .filter { $1.lastPathComponent != gir.lastPathComponent }
             .map(\.value)
     }
-
+    
+    /// This function performs "deep search" using `pkg-config` in order to get all packages that
+    /// are needed by this package and it's dependencies.
+    /// - Parameter package: The root `pkg-config` package name
+    /// - Returns: Set of all dependencies.
     private static func getAllPkgConfigDependencies(for package: String) throws -> Set<String> {
         var explored: Set<String> = []
         var toExplore: Set<String> = [package]
 
+        // Call `pkg-config` until it was called once for all searched packages.
         while !toExplore.isEmpty {
             let executing = toExplore.removeFirst()
             explored.insert(executing)
 
             try getPkgConfigDependencies(for: executing).forEach { result in
+                // Schedule all dependencies of the `pkg-config` package
+                // to be explored unless a dependency was already explored.
                 if !explored.contains(result) {
                     toExplore.insert(result)
                 }
@@ -142,29 +216,44 @@ struct Plan {
 
         return explored
     }
-
+    
+    /// Get other `pkg-config` packages, that the specified package depends on. The `pkg-config` won't
+    /// perform a "deep search" of the dependency graph.
+    /// - Parameter package: The name of the `pkg-config` package.
+    /// - Returns: The list of dependencies.
     private static func getPkgConfigDependencies(for package: String) throws -> [String] {
         guard let output = try executeAndWait("pkg-config", arguments: ["--print-requires", package]) else {
             return []
         }
 
+        // Each dependency is on separate line
         let dependecyRecord = output.components(separatedBy: .newlines)
+        // If the pkg-config package requires specific version, the version is specified
+        // on the same line separated by whitespace. We don't need this information, we
+        // only need the name of the package.
         let packageNames = dependecyRecord.compactMap { line in
             line.components(separatedBy: .whitespaces).first
         }
 
+        // If package has no dependencies, empty string is returned. We need to get rid of it.
         return packageNames.filter { !$0.isEmpty }
     }
-
+    
+    /// This function parses the `.gir` file using libxml2 in order to get dependency metadata from the `.gir` file.
+    /// - Parameter gir: The location of the `.gir` file.
     private static func parsePackageInfo(for gir: URL) throws -> GirPackageMetadata {
         guard let xml = XMLDocument(fromFile: gir.path) else {
             throw Error.girNotFound(named: gir.lastPathComponent)
         }
 
         // @rhx please check this code
+        // This operation might be expansive, however the element `repository` is usualy the first.
+        // We need to do this, because before namespaces are loaded, the xpath does not work.
         if let repository = xml.first(where: { $0.name == "repository" }) {
+            // Load namespaces
             let namespaces = repository.namespaces
 
+            // Search for first occurance of `package` element. We expect only one package - we do not expect that a `.gir` file describes multiple pkg-config packages.
             guard 
                 let packageName = xml.xpath(
                     "/gir:repository/gir:package", 
@@ -173,6 +262,7 @@ struct Plan {
                 )?.first?.attribute(named: "name") 
             else { throw Error.girParsingFailed }
 
+            // Search for all occurances of `include` element. We expect, that the attributes of the element represent an existing `.gir` file.
             let dependencies = xml.xpath(
                 "/gir:repository/gir:include", 
                 namespaces: namespaces, 

--- a/Sources/libgir2swift/utilities/planning.swift
+++ b/Sources/libgir2swift/utilities/planning.swift
@@ -120,7 +120,7 @@ struct Plan {
         // All pkg-config packages passed in the argument are scanned and their `libdir` values are reported.
         // TODO: This is major performance hit. Optimization desirable.
         let homebrewPaths = pkgConfig.compactMap { pkgName -> URL? in 
-            let libDir = try? executeAndWait("pkg-config", arguments: ["--variable=libdir", pkgName])
+            let libDir = try? executeAndWait("env", arguments: ["pkg-config", "--variable=libdir", pkgName])
             return libDir.flatMap { 
                 let libDirUrl = URL(fileURLWithPath: $0, isDirectory: true)
                 return URL(string: homebrewRelativeGirLocation, relativeTo: libDirUrl)
@@ -222,7 +222,7 @@ struct Plan {
     /// - Parameter package: The name of the `pkg-config` package.
     /// - Returns: The list of dependencies.
     private static func getPkgConfigDependencies(for package: String) throws -> [String] {
-        guard let output = try executeAndWait("pkg-config", arguments: ["--print-requires", package]) else {
+        guard let output = try executeAndWait("env", arguments: ["pkg-config", "--print-requires", package]) else {
             return []
         }
 

--- a/Sources/libgir2swift/utilities/planning.swift
+++ b/Sources/libgir2swift/utilities/planning.swift
@@ -1,5 +1,4 @@
 import Foundation
-import FoundationNetworking
 import Yams
 import SwiftLibXML
 

--- a/Sources/libgir2swift/utilities/planning.swift
+++ b/Sources/libgir2swift/utilities/planning.swift
@@ -94,7 +94,7 @@ struct Plan {
     }
 
     private static func loadPrerequisities(from gir: URL, pkgConfig: String, prerequisities: [Prerequisity]?) throws -> [URL] {
-        var explored: [String: URL] = [ gir.deletingLastPathComponent().lastPathComponent : gir ]
+        var explored: [String: URL] = [:]
         var toExplore: Set<String> = Set(try parsePackageInfo(for: gir).dependency.map(\.girName) + (prerequisities?.map(\.girName) ?? []))
 
         var pkgConfigCandidates: Set<String> = []
@@ -120,7 +120,9 @@ struct Plan {
             }
         }
 
-        return Array(explored.values)
+        return explored
+            .filter { $1.lastPathComponent != gir.lastPathComponent }
+            .map(\.value)
     }
 
     private static func getAllPkgConfigDependencies(for package: String) throws -> Set<String> {


### PR DESCRIPTION
This contains following features:
 - [x] Yaml parsing and first manifest definition
 - [x] Searching for `.gir` files is now integrated into the `gir2swift`
 - [x] Determining the prerequisities is now integrated into the `gir2swift` based on contents of .gir files
 - [x] Introducting new `Plan` abstraction, that should in future drive all actions (parsing, generation, postprocessing)
 - [ ] ~~Scripts `gir2swift-manifest` are removed, the `gir2swift-generation-driver` is now independent.~~

~~Following features will be deprecated after this PR is finished and accepted:~~
 - ~~The ability to pass .gir files directly to gir2swift~~
 - ~~The ability to pass prerequisites directly to gir2swift~~
 - ~~The ability to pass pkg-config name directly to gir2swift~~

This PR introduces new dependency: https://github.com/jpsim/Yams.git .
_Notice: Yams is also a dependency of some official tools, like Sourcekit-LSP https://github.com/apple/sourcekit-lsp_

This PR is a step towards the https://github.com/rhx/SwiftGtk/issues/48

Accepting this PR will open doors for https://github.com/rhx/gir2swift/issues/20