### PR TITLE
Opaque declarations generation and planning troubleshooting

### DIFF
--- a/Sources/libgir2swift/models/Gir2Swift.swift
+++ b/Sources/libgir2swift/models/Gir2Swift.swift
@@ -64,6 +64,9 @@ public struct Gir2Swift: ParsableCommand {
     @Argument(help: "The .gir metadata files to process. Gir files specified in CLI are merged with those specified in the manifest.")
     var girFiles: [String] = []
 
+    /// Skips all other generations steps and prints opaque struct stylized declarations for each record and class to stdout.
+    @Flag(name: .long, help: "Skips all other generations steps and prints opaque struct stylized declarations for each record and class to stdout.")
+    var opaqueDeclarations: Bool = false
 
     /// Designated initialiser
     public init() {}
@@ -116,8 +119,16 @@ public struct Gir2Swift: ParsableCommand {
 
         let target = outputDirectory.isEmpty ? manifestPlan?.outputDirectory : outputDirectory
         let generateAlphaFiles = alphaNames || manifestPlan?.useAlphaNames ?? false
-        for girFile in girFilesToGenerate {
-            process_gir(file: girFile, boilerPlate: moduleBoilerPlate, to: target, split: singleFilePerClass, generateAll: allFilesGenerate, useAlphaNames: generateAlphaFiles, postProcess: postProcess + (manifestPlan?.postProcess ?? []))
+
+        switch opaqueDeclarations {
+        case true:
+            for girFile in girFilesToGenerate {
+                process_gir_to_opaque_decls(file: girFile, generateAll: allFilesGenerate)
+            }
+        case false:
+            for girFile in girFilesToGenerate {
+                process_gir(file: girFile, boilerPlate: moduleBoilerPlate, to: target, split: singleFilePerClass, generateAll: allFilesGenerate, useAlphaNames: generateAlphaFiles, postProcess: postProcess + (manifestPlan?.postProcess ?? []))
+            }
         }
 
         if verbose {

--- a/Sources/libgir2swift/models/gir elements/GirRecord.swift
+++ b/Sources/libgir2swift/models/gir elements/GirRecord.swift
@@ -14,6 +14,8 @@ extension GIR {
         public override var kind: String { return "Record" }
         /// C language symbol prefix
         public let cprefix: String
+        /// Corresponding C type of the record (gir-1.0.rnc:214)
+        public let correspondingCType: String?
         /// C type getter function
         public let typegetter: String?
         /// Methods associated with this record
@@ -72,8 +74,9 @@ extension GIR {
         ///   - comment: Documentation text for the constant
         ///   - introspectable: Set to `true` if introspectable
         ///   - deprecated: Documentation on deprecation status if non-`nil`
-        public init(name: String, type: TypeReference, cprefix: String, typegetter: String? = nil, isGTypeStructForType: String? = nil, methods: [Method] = [], functions: [Function] = [], constructors: [Method] = [], properties: [Property] = [], fields: [Field] = [], signals: [Signal] = [], interfaces: [String] = [], comment: String = "", introspectable: Bool = false, deprecated: String? = nil) {
+        public init(name: String, type: TypeReference, cprefix: String, correspondingCType: String? = nil, typegetter: String? = nil, isGTypeStructForType: String? = nil, methods: [Method] = [], functions: [Function] = [], constructors: [Method] = [], properties: [Property] = [], fields: [Field] = [], signals: [Signal] = [], interfaces: [String] = [], comment: String = "", introspectable: Bool = false, deprecated: String? = nil) {
             self.cprefix = cprefix
+            self.correspondingCType = correspondingCType
             self.typegetter = typegetter
             self.isGTypeStructForType = isGTypeStructForType
             self.methods = methods
@@ -92,6 +95,8 @@ extension GIR {
         ///   - index: Index within the siblings of the `node`
         public init(node: XMLElement, at index: Int) {
             cprefix = node.attribute(named: "symbol-prefix") ?? ""
+
+            correspondingCType = node.attribute(named: "type")
 
             // Regarding "intern": https://gitlab.gnome.org/GNOME/gobject-introspection/-/blob/gnome-3-36/girepository/giregisteredtypeinfo.c
             if let typegetter = node.attribute(named: "get-type"), typegetter != "intern" {


### PR DESCRIPTION
There are two main additions in this PR:

## Opaque declaration generation
New flag `-opaque-declarations` is added. If this flag is used, `gir2swift` will attempt to create plan and load girs as usual. Unlike in normal operation mode, it won't generate wrapper, but print all possible declaration for thought-to-be opaque types.
This feature should save some typing in the future.

## Fixes to planning
There were two major issues with planning. If `pkg-config` name was not specified in `.yaml`, default name was provided derived from the name of the gir. This was done silently.
This lead to failure to generate SwiftGtk, since gir name for Gtk is "Gtk-3.0" but `pkg-config` name is "gtk+-3.0". The gir2swift now prints warning to stderr in case that pkg-config name is missing.

Second issue was caused by some ill formated gir files that are to my knowledge not `GLib/GObject` based. In this case, the main culprit was `xlib-2.0.gir` which is a dependency, but it lacks the repository name in the top-level repository declaration. This caused Planner to panic and throw an error. 
In this PR, if the planner catches error due to ill-formated gir, it only prints warning into the stderr and continues in planning. 

